### PR TITLE
[WIP] Lazy interface

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,21 @@
+# https://abronan.com/building-a-rust-project-on-circleci/
+# https://hub.docker.com/_/rust/
+
+version: 2
+
+jobs:
+  build:
+    docker:
+      - image: rust:1-stretch
+    steps:
+      - checkout
+      - restore_cache:
+          key: cargo-cache
+      - run:
+          name: Run Circle Example
+          command: cargo run --example circle
+      - save_cache:
+          key: cargo-cache
+          paths:
+            - "~/.cargo"
+            - "./target"

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,13 +9,13 @@ rust:
 matrix:
   include:
   - env: RUSTFMT
-    rust: 1.24.0  # `stable`: Locking down for consistent behavior
+    rust: 1.25.0  # `stable`: Locking down for consistent behavior
     install:
     - rustup component add rustfmt-preview
     script:
     - cargo fmt -- --write-mode=diff
   - env: RUSTFLAGS="-D warnings"
-    rust: 1.24.0  # `stable`: Locking down for consistent behavior
+    rust: 1.25.0  # `stable`: Locking down for consistent behavior
     script:
     - cargo check --tests
   - env: CLIPPY_VERSION=0.0.179

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,4 @@
+[workspace]
 [package]
 name = "ci-detective"
 version = "0.1.0"
@@ -11,8 +12,11 @@ readme = "README.md"
 categories = ["development-tools::testing"]
 keywords = ["ci"]
 
+[dependencies]
+ci-detective-internal-derive = { version = "0.0.1", path = "./ci-detective-internal-derive/" }
+
 [features]
-nightly = []
+nightly = ["ci-detective-internal-derive/nightly"]
 
 [badges]
 travis-ci = { repository = "crate-ci/ci-detective" }

--- a/ci-detective-internal-derive/Cargo.toml
+++ b/ci-detective-internal-derive/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "ci-detective-internal-derive"
+version = "0.0.1"
+authors = ["Christopher Durham <cad97@cad97.com>"]
+
+[lib]
+proc-macro = true
+
+[dependencies]
+quote = "0.5"
+proc-macro2 = "0.3"
+
+[dependencies.syn]
+version = "0.13"
+features = ["extra-traits"]
+
+[features]
+nightly = ["proc-macro2/nightly"]

--- a/ci-detective-internal-derive/src/lib.rs
+++ b/ci-detective-internal-derive/src/lib.rs
@@ -1,0 +1,301 @@
+#![recursion_limit = "128"]
+
+extern crate proc_macro;
+extern crate proc_macro2;
+#[macro_use]
+extern crate quote;
+extern crate syn;
+
+#[proc_macro_derive(CI, attributes(ci))]
+pub fn derive_ci(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
+    let input: syn::DeriveInput = syn::parse(input).unwrap();
+    let ci: syn::Path = syn::parse_str("ci").unwrap();
+
+    let name = input.ident;
+    let (impl_generics, ty_generics, where_clause) = input.generics.split_for_impl();
+
+    let data = if let syn::Data::Struct(data) = input.data {
+        data
+    } else {
+        panic!("derive(CI) only works for structs")
+    };
+
+    let fields = if let syn::Fields::Named(fields) = data.fields {
+        fields
+    } else {
+        panic!("derive(CI) only works with named fields")
+    };
+
+    let member_access = fields.named.iter().map(impl_member_access_fn);
+    let field = fields.named.iter().filter_map(|field| field.ident);
+    let field2 = fields.named.iter().filter_map(|field| field.ident);
+    let requires_var = input
+        .attrs
+        .iter()
+        .filter(|attr| attr.path == ci)
+        .map(unwrap_ci_attribute)
+        .filter(|meta| meta.name().as_ref() == "requires")
+        .flat_map(|meta| {
+            if let syn::Meta::List(meta) = meta {
+                meta.nested
+                    .into_iter()
+                    .map(|meta| {
+                        if let syn::NestedMeta::Meta(meta) = meta {
+                            meta
+                        } else {
+                            panic!("#[ci(requires(...))] takes a list of name/value pairs")
+                        }
+                    })
+                    .map(|meta| {
+                        if let syn::Meta::NameValue(meta) = meta {
+                            meta
+                        } else {
+                            panic!("#[ci(requires(...))] takes a list of name/value pairs")
+                        }
+                    })
+                    .map(|meta| meta.ident)
+            } else {
+                panic!("#[ci(requires(...))] takes a list of name/value pairs")
+            }
+        });
+    let requires_val = input
+        .attrs
+        .iter()
+        .filter(|attr| attr.path == ci)
+        .map(unwrap_ci_attribute)
+        .filter(|meta| meta.name().as_ref() == "requires")
+        .flat_map(|meta| {
+            if let syn::Meta::List(meta) = meta {
+                meta.nested
+                    .into_iter()
+                    .map(|meta| {
+                        if let syn::NestedMeta::Meta(meta) = meta {
+                            meta
+                        } else {
+                            panic!("#[ci(requires(...))] takes a list of name/value pairs")
+                        }
+                    })
+                    .map(|meta| {
+                        if let syn::Meta::NameValue(meta) = meta {
+                            meta
+                        } else {
+                            panic!("#[ci(requires(...))] takes a list of name/value pairs")
+                        }
+                    })
+                    .map(|meta| meta.lit)
+            } else {
+                panic!("#[ci(requires(...))] takes a list of name/value pairs")
+            }
+        });
+
+    let expanded = quote! {
+        impl #impl_generics #name #ty_generics #where_clause {
+            /// Construct a lazy instance of this CI's configuration.
+            ///
+            /// Returns None if the environment doesn't look like the CI's.
+            /// Most CI has a set of environment variables which identify it,
+            /// such as `TRAVIS=true` for Travis CI. Those are checked eagerly
+            /// here.
+            pub fn lazy() -> Option<Self> {
+                if !(
+                    #(::env(stringify!(#requires_var))? == #requires_val &&)*
+                    true
+                ) { return None; }
+                Some(Self {#(#field: None,)*})
+                // if !(
+                //     //$(::env($require_environment_present).is_some() &&)*
+                //     $(::env(stringify!($require_environment_var))? == $require_environment_val &&)*
+                //     true
+                // ) { return None; }
+                // Some($CI {$(
+                //     $member: ::LazyEnv::new(stringify!($member_env)),
+                // )*})
+            }
+
+            pub(crate) fn load(&mut self) {
+                #(let _ = self.#field2();)*
+            }
+
+            /// Construct an instance of this CI's configuration and load it eagerly.
+            ///
+            /// # Panics
+            ///
+            /// If any of the expected environment variables are not present.
+            pub fn eager() -> Self {
+                let mut ci = Self::lazy().expect(concat!(
+                    "Environment does not look like ",
+                    stringify!(#name),
+                ));
+                ci.load();
+                ci
+            }
+        }
+
+        impl #impl_generics #name #ty_generics #where_clause {
+            #(#member_access)*
+        }
+    };
+    expanded.into()
+}
+
+fn unwrap_ci_attribute(attr: &syn::Attribute) -> syn::Meta {
+    assert_eq!(attr.path, syn::parse_str("ci").unwrap());
+    let meta = attr.interpret_meta()
+        .unwrap_or_else(|| panic!("malformed #[ci] attribute `{}`", quote!(#attr)));
+    let meta = if let syn::Meta::List(meta) = meta {
+        meta
+    } else {
+        panic!("#[ci] attribute must use scoping #[ci(...)]")
+    };
+    let meta = if meta.nested.len() == 1 {
+        meta.nested.into_pairs().next().unwrap().into_value()
+    } else {
+        panic!("#[ci] takes exactly one argument")
+    };
+    let meta = if let syn::NestedMeta::Meta(meta) = meta {
+        meta
+    } else {
+        panic!("malformed argument to #[ci] `{}`", quote!(#meta))
+    };
+    meta
+}
+
+fn impl_member_access_fn(member: &syn::Field) -> quote::Tokens {
+    let ci: syn::Path = syn::parse_str("ci").unwrap();
+
+    let ident = member
+        .ident
+        .unwrap_or_else(|| panic!("derive(CI) only supports named fields"));
+    let ty = {
+        if let syn::Type::Path(ref ty) = member.ty {
+            let ty = ty.path.segments.first().unwrap().into_value();
+            if ty.ident.as_ref() == "Option" {
+                if let syn::PathArguments::AngleBracketed(ref arguments) = ty.arguments {
+                    if let &syn::GenericArgument::Type(ref ty) =
+                        arguments.args.first().unwrap().into_value()
+                    {
+                        ty
+                    } else {
+                        panic!("CI members must be Option<...>");
+                    }
+                } else {
+                    panic!("CI members must be Option<...>");
+                }
+            } else {
+                panic!("CI members must be Option<...>");
+            }
+        } else {
+            panic!("CI members must be Option<...>");
+        }
+    };
+
+    // TODO(RUST 1.26): Remove the PathBuf hack as now PathBuf is ParseStr
+    let require_path_buf_hack = if let &syn::Type::Path(ref ty) = ty {
+        ty.path.segments.last().unwrap().into_value().ident.as_ref() == "PathBuf"
+    } else {
+        false
+    };
+
+    let docs = member.attrs.iter().filter(|attr| {
+        attr.path
+            .segments
+            .first()
+            .unwrap()
+            .into_value()
+            .ident
+            .as_ref() == "doc"
+    });
+    let expected = member
+        .attrs
+        .iter()
+        .filter(|attr| attr.path == ci)
+        .map(unwrap_ci_attribute)
+        .filter(|meta| {
+            if let &syn::Meta::Word(ref word) = meta {
+                word.as_ref() == "expected"
+            } else {
+                false
+            }
+        })
+        .count();
+    let env = {
+        let mut env_attr = member
+            .attrs
+            .iter()
+            .filter(|attr| attr.path == ci)
+            .map(unwrap_ci_attribute)
+            .filter_map(|meta| {
+                if let syn::Meta::NameValue(meta) = meta {
+                    Some(meta.lit)
+                } else {
+                    None
+                }
+            });
+        let env = env_attr.next().unwrap_or_else(|| {
+            panic!(
+                "member `{}` does not have a `#[ci(env = ...)]` attribute",
+                ident
+            )
+        });
+        assert!(
+            env_attr.next().is_none(),
+            "member `{}` has a duplicate `#[ci(env = ...)]` attribute",
+            ident
+        );
+        env
+    };
+
+    if expected > 1 {
+        panic!("multiple #[ci(expected)] on `{}`", ident)
+    } else if expected == 1 {
+        if require_path_buf_hack {
+            quote! {
+                #(#docs)*
+                pub fn #ident(&mut self) -> &#ty {
+                    if self.#ident.is_none() {
+                        self.#ident = ::env(#env).map(Into::into);
+                    }
+                    self.#ident.as_ref().unwrap_or_else(|| panic!(
+                        "Environment variable {} expected to parse to {} but failed; was {:?}",
+                        #env, stringify!(#ty), ::env(#env),
+                    ))
+                }
+            }
+        } else {
+            quote! {
+                #(#docs)*
+                pub fn #ident(&mut self) -> &#ty {
+                    if self.#ident.is_none() {
+                        self.#ident = ::env(#env).and_then(|it| it.parse().ok());
+                    }
+                    self.#ident.as_ref().unwrap_or_else(|| panic!(
+                        "Environment variable {} expected to parse to {} but failed; was {:?}",
+                        #env, stringify!(#ty), ::env(#env),
+                    ))
+                }
+            }
+        }
+    } else {
+        if require_path_buf_hack {
+            quote! {
+                #(#docs)*
+                pub fn #ident(&mut self) -> &#ty {
+                    if self.#ident.is_none() {
+                        self.#ident = ::env(#env).map(Into::into);
+                    }
+                    self.#ident.as_ref()
+                }
+            }
+        } else {
+            quote! {
+                #(#docs)*
+                pub fn #ident(&mut self) -> Option<&#ty> {
+                    if self.#ident.is_none() {
+                        self.#ident = ::env(#env).and_then(|it| it.parse().ok());
+                    }
+                    self.#ident.as_ref()
+                }
+            }
+        }
+    }
+}

--- a/examples/circle.rs
+++ b/examples/circle.rs
@@ -1,0 +1,6 @@
+extern crate ci_detective;
+
+fn main() {
+    let circle = ci_detective::Circle::eager();
+    println!("{:?}", circle)
+}

--- a/src/circle.rs
+++ b/src/circle.rs
@@ -1,108 +1,124 @@
 use std::path::PathBuf;
 
-ci! {
-    #[ci(require(CI = "true", CIRCLECI = "true"))]
-    /// Circle CI
-    ///
-    /// # References
-    ///
-    /// - <https://circleci.com/docs/2.0/env-vars/#circleci-built-in-environment-variables>
-    /// - <https://github.com/codecov/codecov-bash/blob/8b76995ad4a95a61cecd4b049a448a402d91d197/codecov#L548-L568>
-    pub struct Circle {
-        #[ci(env(HOME))]
-        /// Your home directory.
-        home: PathBuf!,
+/// Circle CI
+///
+/// # References
+///
+/// - <https://circleci.com/docs/2.0/env-vars/#circleci-built-in-environment-variables>
+/// - <https://github.com/codecov/codecov-bash/blob/8b76995ad4a95a61cecd4b049a448a402d91d197/codecov#L548-L568>
+#[derive(Clone, Debug, CI)]
+#[ci(require(CI = "true", CIRCLECI = "true"))]
+pub struct Circle {
+    /// Your home directory.
+    #[ci(env = "HOME")]
+    #[ci(expected)]
+    home: Option<PathBuf>,
 
-        #[ci(env(CIRCLE_BRANCH))]
-        /// The name of the Git branch currently being built.
-        branch: String!,
+    /// The name of the Git branch currently being built.
+    #[ci(env = "CIRCLE_BRANCH")]
+    #[ci(expected)]
+    branch: Option<String>,
 
-        #[ci(env(CIRCLE_NODE_TOTAL))]
-        /// An integer representing the number of total build instances.
-        node_total: u32!,
+    /// An integer representing the number of total build instances.
+    #[ci(env = "CIRCLE_NODE_TOTAL")]
+    #[ci(expected)]
+    node_total: Option<u32>,
 
-        #[ci(env(CIRCLE_BUILD_NUM))]
-        /// An integer between 0 and (`node_total` - 1) representing a specific build instance.
-        node_index: u32!,
+    /// An integer between 0 and (`node_total` - 1) representing a specific build instance.
+    #[ci(env = "CIRCLE_BUILD_NUM")]
+    #[ci(expected)]
+    node_index: Option<u32>,
 
-        #[ci(env(CIRCLE_PREVIOUS_BUILD_NUM))]
-        /// The CircleCI build number.
-        build_num: u32!,
+    /// The CircleCI build number.
+    #[ci(env = "CIRCLE_PREVIOUS_BUILD_NUM")]
+    #[ci(expected)]
+    build_num: Option<u32>,
 
-        #[ci(env(CIRCLE_PREVIOUS_BUILD_NUM))]
-        /// The number of previous builds in the branch.
-        previous_build_num: u32!,
+    /// The number of previous builds in the branch.
+    #[ci(env = "CIRCLE_PREVIOUS_BUILD_NUM")]
+    #[ci(expected)]
+    previous_build_num: Option<u32>,
 
-        #[ci(env(CIRCLE_BUILD_URL))]
-        /// The URL for the current build.
-        build_url: String!,
+    /// The URL for the current build.
+    #[ci(env = "CIRCLE_BUILD_URL")]
+    #[ci(expected)]
+    build_url: Option<String>,
 
-        #[ci(env(CIRCLE_SHA1))]
-        /// The SHA1 hash for the current build’s last commit.
-        sha1: String!,
+    /// The SHA1 hash for the current build’s last commit.
+    #[ci(env = "CIRCLE_SHA1")]
+    #[ci(expected)]
+    sha1: Option<String>,
 
-        #[ci(env(CIRCLE_USERNAME))]
-        /// The GitHub/Bitbucket username of the user who triggered the build.
-        username: String!,
+    /// The GitHub/Bitbucket username of the user who triggered the build.
+    #[ci(env = "CIRCLE_USERNAME")]
+    #[ci(expected)]
+    username: Option<String>,
 
-        #[ci(env(CIRCLE_JOB))]
-        /// The current job’s name.
-        job: String!,
+    /// The current job’s name.
+    #[ci(env = "CIRCLE_JOB")]
+    #[ci(expected)]
+    job: Option<String>,
 
-        #[ci(env(CIRCLE_WORKING_DIRECTORY))]
-        /// The `working_directory` for the current job.
-        working_directory: PathBuf!,
+    /// The `working_directory` for the current job.
+    #[ci(env = "CIRCLE_WORKING_DIRECTORY")]
+    #[ci(expected)]
+    working_directory: Option<PathBuf>,
 
-        #[ci(env(CIRCLE_COMPARE_URL))]
-        /// The GitHub/Bitbucket compare URL between commits in the build.
-        compare_url: String!,
+    /// The GitHub/Bitbucket compare URL between commits in the build.
+    #[ci(env = "CIRCLE_COMPARE_URL")]
+    #[ci(expected)]
+    compare_url: Option<String>,
 
-        #[ci(env(CIRCLE_REPOSITORY_URL))]
-        /// The GitHub/Bitbucket repository URL.
-        repository_url: String!,
+    /// The GitHub/Bitbucket repository URL.
+    #[ci(env = "CIRCLE_REPOSITORY_URL")]
+    #[ci(expected)]
+    repository_url: Option<String>,
 
-        #[ci(env(CIRCLE_PR_NUMBER))]
-        /// The GitHub/Bitbucket pull request number.
-        pr_number: u32?,
+    /// The GitHub/Bitbucket pull request number.
+    #[ci(env = "CIRCLE_PR_NUMBER")]
+    pr_number: Option<u32>,
 
-        #[ci(env(CIRCLE_PR_REPONAME))]
-        /// The GitHub/Bitbucket repository name in which the pull request was made.
-        pr_reponame: String?,
+    /// The GitHub/Bitbucket repository name in which the pull request was made.
+    #[ci(env = "CIRCLE_PR_REPONAME")]
+    pr_reponame: Option<String>,
 
-        #[ci(env(CIRCLE_PR_USERNAME))]
-        /// The GitHub/Bitbucket username of the user who created the pull request.
-        pr_username: String?,
+    /// The GitHub/Bitbucket username of the user who created the pull request.
+    #[ci(env = "CIRCLE_PR_USERNAME")]
+    pr_username: Option<String>,
 
-        #[ci(env(CIRCLE_PULL_REQUESTS))]
-        /// Comma-separated list of URLs of pull requests this build is a part of.
-        pull_requests: String?,
+    /// Comma-separated list of URLs of pull requests this build is a part of.
+    #[ci(env = "CIRCLE_PULL_REQUESTS")]
+    pull_requests: Option<String>,
 
-        #[ci(env(CIRCLE_PULL_REQUEST))]
-        /// If this build is part of only one pull request, its URL will be populated here.
-        /// If there was more than one pull request,
-        /// it will contain one of the pull request URLs (picked randomly).
-        pull_request: String?,
+    /// If this build is part of only one pull request, its URL will be populated here.
+    /// If there was more than one pull request,
+    /// it will contain one of the pull request URLs (picked randomly).
+    #[ci(env = "CIRCLE_PULL_REQUEST")]
+    pull_request: Option<String>,
 
-        #[ci(env(CIRCLE_TAG))]
-        /// The name of the git tag being tested, e.g. ‘release-v1.5.4’, if the build is running for a tag.
-        tag: String?,
+    /// The name of the git tag being tested, e.g. ‘release-v1.5.4’, if the build is running for a tag.
+    #[ci(env = "CIRCLE_TAG")]
+    tag: Option<String>,
 
-        #[ci(env(CIRCLE_PROJECT_USERNAME))]
-        /// The username or organization name of the project being tested,
-        /// i.e. “foo” in circleci.com/gh/foo/bar/123.
-        project_username: String!,
+    /// The username or organization name of the project being tested,
+    /// i.e. “foo” in circleci.com/gh/foo/bar/123.
+    #[ci(env = "CIRCLE_PROJECT_USERNAME")]
+    #[ci(expected)]
+    project_username: Option<String>,
 
-        #[ci(env(CIRCLE_PROJECT_REPONAME))]
-        /// The repository name of the project being tested,
-        /// i.e. “bar” in circleci.com/gh/foo/bar/123.
-        project_reponame: String!,
+    /// The repository name of the project being tested,
+    /// i.e. “bar” in circleci.com/gh/foo/bar/123.
+    #[ci(env = "CIRCLE_PROJECT_REPONAME")]
+    #[ci(expected)]
+    project_reponame: Option<String>,
 
-        #[ci(env(CIRCLE_INTERNAL_TASK_DATA))]
-        /// The directory where test timing data can be found.
-        internal_task_data: PathBuf!,
+    /// The directory where test timing data can be found.
+    #[ci(env = "CIRCLE_INTERNAL_TASK_DATA")]
+    #[ci(expected)]
+    internal_task_data: Option<PathBuf>,
 
-        #[ci(env(CIRCLE_STAGE))]
-        /// The job being executed. The default 2.0 job is `build` without using Workflows.
-        stage: String!,
-    }
+    /// The job being executed. The default 2.0 job is `build` without using Workflows.
+    #[ci(env = "CIRCLE_STAGE")]
+    #[ci(expected)]
+    stage: Option<String>,
 }

--- a/src/circle.rs
+++ b/src/circle.rs
@@ -1,108 +1,108 @@
+use std::path::PathBuf;
+
 ci! {
     #[ci(require(CI = "true", CIRCLECI = "true"))]
     /// Circle CI
     ///
     /// # References
     ///
-    /// - <https://circleci.com/docs/1.0/environment-variables/>
+    /// - <https://circleci.com/docs/2.0/env-vars/#circleci-built-in-environment-variables>
     /// - <https://github.com/codecov/codecov-bash/blob/8b76995ad4a95a61cecd4b049a448a402d91d197/codecov#L548-L568>
     pub struct Circle {
+        #[ci(env(HOME))]
+        /// Your home directory.
+        home: PathBuf!,
+
+        #[ci(env(CIRCLE_BRANCH))]
+        /// The name of the Git branch currently being built.
+        branch: String!,
+
+        #[ci(env(CIRCLE_NODE_TOTAL))]
+        /// An integer representing the number of total build instances.
+        node_total: u32!,
+
+        #[ci(env(CIRCLE_BUILD_NUM))]
+        /// An integer between 0 and (`node_total` - 1) representing a specific build instance.
+        node_index: u32!,
+
+        #[ci(env(CIRCLE_PREVIOUS_BUILD_NUM))]
+        /// The CircleCI build number.
+        build_num: u32!,
+
+        #[ci(env(CIRCLE_PREVIOUS_BUILD_NUM))]
+        /// The number of previous builds in the branch.
+        previous_build_num: u32!,
+
+        #[ci(env(CIRCLE_BUILD_URL))]
+        /// The URL for the current build.
+        build_url: String!,
+
+        #[ci(env(CIRCLE_SHA1))]
+        /// The SHA1 hash for the current build’s last commit.
+        sha1: String!,
+
+        #[ci(env(CIRCLE_USERNAME))]
+        /// The GitHub/Bitbucket username of the user who triggered the build.
+        username: String!,
+
+        #[ci(env(CIRCLE_JOB))]
+        /// The current job’s name.
+        job: String!,
+
+        #[ci(env(CIRCLE_WORKING_DIRECTORY))]
+        /// The `working_directory` for the current job.
+        working_directory: PathBuf!,
+
+        #[ci(env(CIRCLE_COMPARE_URL))]
+        /// The GitHub/Bitbucket compare URL between commits in the build.
+        compare_url: String!,
+
+        #[ci(env(CIRCLE_REPOSITORY_URL))]
+        /// The GitHub/Bitbucket repository URL.
+        repository_url: String!,
+
+        #[ci(env(CIRCLE_PR_NUMBER))]
+        /// The GitHub/Bitbucket pull request number.
+        pr_number: u32!,
+
+        #[ci(env(CIRCLE_PR_REPONAME))]
+        /// The GitHub/Bitbucket repository name in which the pull request was made.
+        pr_reponame: String!,
+
+        #[ci(env(CIRCLE_PR_USERNAME))]
+        /// The GitHub/Bitbucket username of the user who created the pull request.
+        pr_username: String!,
+
+        #[ci(env(CIRCLE_PULL_REQUESTS))]
+        /// Comma-separated list of URLs of pull requests this build is a part of.
+        pull_requests: String!,
+
+        #[ci(env(CIRCLE_PULL_REQUEST))]
+        /// If this build is part of only one pull request, its URL will be populated here.
+        /// If there was more than one pull request,
+        /// it will contain one of the pull request URLs (picked randomly).
+        pull_request: String!,
+
+        #[ci(env(CIRCLE_TAG))]
+        /// The name of the git tag being tested, e.g. ‘release-v1.5.4’, if the build is running for a tag.
+        tag: String?,
+
         #[ci(env(CIRCLE_PROJECT_USERNAME))]
         /// The username or organization name of the project being tested,
-        /// i.e. `foo` in `circleci.com/gh/foo/bar/123`
+        /// i.e. “foo” in circleci.com/gh/foo/bar/123.
         project_username: String!,
 
         #[ci(env(CIRCLE_PROJECT_REPONAME))]
         /// The repository name of the project being tested,
-        /// i.e. `bar` in `circleci.com/gh/foo/bar/123`
+        /// i.e. “bar” in circleci.com/gh/foo/bar/123.
         project_reponame: String!,
 
-        #[ci(env(CIRCLE_BRANCH))]
-        /// The name of the Git branch being tested, e.g. `master`,
-        /// if the build is running for a branch.
-        branch: String?,
+        #[ci(env(CIRCLE_INTERNAL_TASK_DATA))]
+        /// The directory where test timing data can be found.
+        internal_task_data: PathBuf!,
 
-        #[ci(env(CIRCLE_TAG))]
-        /// The name of the git tag being tested, e.g. `release-v1.5.4`,
-        /// if the build is running [for a tag](https://circleci.com/docs/1.0/configuration/#tags).
-        tag: String?,
-
-        #[ci(env(CIRCLE_SHA1))]
-        /// The SHA1 of the commit being tested.
-        sha1: String!,
-
-        #[ci(env(CIRCLE_REPOSITORY_URL))]
-        /// A link to the homepage for the current repository,
-        /// for example, `https://github.com/circleci/frontend`.
-        repository_url: String!,
-
-        #[ci(env(CIRCLE_COMPARE_URL))]
-        /// A link to GitHub’s comparison view for this push.
-        /// Not present for builds that are triggered by GitHub pushes.
-        compare_url: String?,
-
-        #[ci(env(CIRCLE_BUILD_URL))]
-        /// A permanent link to the current build,
-        /// for example, `https://circleci.com/gh/circleci/frontend/933`.
-        build_url: String!,
-
-        #[ci(env(CIRCLE_BUILD_NUM))]
-        /// The build number, same as in `circleci.com/gh/foo/bar/123`
-        build_num: usize!,
-
-        #[ci(env(CIRCLE_PREVIOUS_BUILD_NUM))]
-        /// The build number of the previous build, same as in `circleci.com/gh/foo/bar/123`
-        previous_build_num: usize?,
-
-        #[ci(env(CIRCLE_PULL_REQUESTS))]
-        /// Comma-separated list of pull requests this build is a part of.
-        pull_requests: String?,
-
-        #[ci(env(CIRCLE_PULL_REQUEST))]
-        /// If this build is part of only one pull request, its URL will be populated here. If there was
-        /// more than one pull request, it will contain one of the pull request URLs (picked randomly).
-        pull_request: String?,
-
-        #[ci(env(CIRCLE_ARTIFACTS))]
-        /// The directory whose contents are automatically saved as
-        /// [build artifacts](https://circleci.com/docs/1.0/build-artifacts/).
-        artifacts: String!,
-
-        #[ci(env(CIRCLE_USERNAME))]
-        /// The GitHub login of the user who either pushed the code
-        /// to GitHub or triggered the build from the UI/API.
-        username: String!,
-
-        #[ci(env(CIRCLE_TEST_REPORTS))]
-        /// The directory whose contents are automatically processed as
-        /// [JUnit test metadata](https://circleci.com/docs/1.0/test-metadata/).
-        test_reports: String!,
-
-        #[ci(env(CIRCLE_PR_USERNAME))]
-        /// When the build is a part of a pull request from a fork,
-        /// The username of the owner of the fork.
-        pr_username: String?,
-
-        #[ci(env(CIRCLE_PR_REPONAME))]
-        /// When the build is a part of a pull request from a fork,
-        /// The name of the repository the pull request was submitted from.
-        pr_reponame: String?,
-
-        #[ci(env(CIRCLE_PR_NUMBER))]
-        /// When the build is a part of a pull request from a fork,
-        /// The number of the pull request this build forms part of.
-        pr_number: usize?,
-
-        #[ci(env(CIRCLE_NODE_TOTAL))]
-        /// The total number of nodes across which the current test is running.
-        node_total: usize!,
-
-        #[ci(env(CIRCLE_NODE_INDEX))]
-        /// The index (0-based) of the current node.
-        node_index: usize!,
-
-        #[ci(env(CIRCLE_BUILD_IMAGE))]
-        /// The build image this build runs on.
-        build_image: String!,
+        #[ci(env(CIRCLE_STAGE))]
+        /// The job being executed. The default 2.0 job is `build` without using Workflows.
+        stage: String!,
     }
 }

--- a/src/circle.rs
+++ b/src/circle.rs
@@ -63,25 +63,25 @@ ci! {
 
         #[ci(env(CIRCLE_PR_NUMBER))]
         /// The GitHub/Bitbucket pull request number.
-        pr_number: u32!,
+        pr_number: u32?,
 
         #[ci(env(CIRCLE_PR_REPONAME))]
         /// The GitHub/Bitbucket repository name in which the pull request was made.
-        pr_reponame: String!,
+        pr_reponame: String?,
 
         #[ci(env(CIRCLE_PR_USERNAME))]
         /// The GitHub/Bitbucket username of the user who created the pull request.
-        pr_username: String!,
+        pr_username: String?,
 
         #[ci(env(CIRCLE_PULL_REQUESTS))]
         /// Comma-separated list of URLs of pull requests this build is a part of.
-        pull_requests: String!,
+        pull_requests: String?,
 
         #[ci(env(CIRCLE_PULL_REQUEST))]
         /// If this build is part of only one pull request, its URL will be populated here.
         /// If there was more than one pull request,
         /// it will contain one of the pull request URLs (picked randomly).
-        pull_request: String!,
+        pull_request: String?,
 
         #[ci(env(CIRCLE_TAG))]
         /// The name of the git tag being tested, e.g. ‘release-v1.5.4’, if the build is running for a tag.

--- a/src/circle.rs
+++ b/src/circle.rs
@@ -1,103 +1,108 @@
-use env;
+ci! {
+    #[ci(require(CI = "true", CIRCLECI = "true"))]
+    /// Circle CI
+    ///
+    /// # References
+    ///
+    /// - <https://circleci.com/docs/1.0/environment-variables/>
+    /// - <https://github.com/codecov/codecov-bash/blob/8b76995ad4a95a61cecd4b049a448a402d91d197/codecov#L548-L568>
+    pub struct Circle {
+        #[ci(env(CIRCLE_PROJECT_USERNAME))]
+        /// The username or organization name of the project being tested,
+        /// i.e. `foo` in `circleci.com/gh/foo/bar/123`
+        project_username: String!,
 
-/// Circle CI
-///
-/// # References
-///
-/// - <https://circleci.com/docs/1.0/environment-variables/>
-/// - <https://github.com/codecov/codecov-bash/blob/8b76995ad4a95a61cecd4b049a448a402d91d197/codecov#L548-L568>
-#[derive(Clone, Debug)]
-#[cfg_attr(feature = "nightly", non_exhaustive)]
-pub struct Circle {
-    /// The username or organization name of the project being tested,
-    /// i.e. `foo` in `circleci.com/gh/foo/bar/123`
-    project_username: String,
-    /// The repository name of the project being tested,
-    /// i.e. `bar` in `circleci.com/gh/foo/bar/123`
-    project_reponame: String,
-    /// The name of the Git branch being tested, e.g. `master`,
-    /// if the build is running for a branch.
-    branch: Option<String>,
-    /// The name of the git tag being tested, e.g. `release-v1.5.4`,
-    /// if the build is running [for a tag](https://circleci.com/docs/1.0/configuration/#tags).
-    tag: Option<String>,
-    /// The SHA1 of the commit being tested.
-    sha1: String,
-    /// A link to the homepage for the current repository,
-    /// for example, `https://github.com/circleci/frontend`.
-    repository_url: String,
-    /// A link to GitHub’s comparison view for this push.
-    /// Not present for builds that are triggered by GitHub pushes.
-    compare_url: Option<String>,
-    /// A permanent link to the current build,
-    /// for example, `https://circleci.com/gh/circleci/frontend/933`.
-    build_url: String,
-    /// The build number, same as in `circleci.com/gh/foo/bar/123`
-    build_num: usize,
-    /// The build number of the previous build, same as in `circleci.com/gh/foo/bar/123`
-    previous_build_num: Option<usize>,
-    /// Comma-separated list of pull requests this build is a part of.
-    pull_requests: Option<String>,
-    /// If this build is part of only one pull request, its URL will be populated here. If there was
-    /// more than one pull request, it will contain one of the pull request URLs (picked randomly).
-    pull_request: Option<String>,
-    /// The directory whose contents are automatically saved as
-    /// [build artifacts](https://circleci.com/docs/1.0/build-artifacts/).
-    artifacts: String,
-    /// The GitHub login of the user who either pushed the code
-    /// to GitHub or triggered the build from the UI/API.
-    username: String,
-    /// The directory whose contents are automatically processed as
-    /// [JUnit test metadata](https://circleci.com/docs/1.0/test-metadata/).
-    test_reports: String,
-    /// When the build is a part of a pull request from a fork,
-    /// The username of the owner of the fork.
-    pr_username: Option<String>,
-    /// When the build is a part of a pull request from a fork,
-    /// The name of the repository the pull request was submitted from.
-    pr_reponame: Option<String>,
-    /// When the build is a part of a pull request from a fork,
-    /// The number of the pull request this build forms part of.
-    pr_number: Option<usize>,
-    /// The total number of nodes across which the current test is running.
-    node_total: usize,
-    /// The index (0-based) of the current node.
-    node_index: usize,
-    /// The build image this build runs on.
-    build_image: String,
-    non_exhaustive: (),
-}
+        #[ci(env(CIRCLE_PROJECT_REPONAME))]
+        /// The repository name of the project being tested,
+        /// i.e. `bar` in `circleci.com/gh/foo/bar/123`
+        project_reponame: String!,
 
-impl Circle {
-    /// Construct this provider's information from the environment.
-    pub fn from_env() -> Option<Self> {
-        if !(env("CI")? == "true" && env("CIRCLECI")? == "true") {
-            return None;
-        }
+        #[ci(env(CIRCLE_BRANCH))]
+        /// The name of the Git branch being tested, e.g. `master`,
+        /// if the build is running for a branch.
+        branch: String?,
 
-        Some(Circle {
-            project_username: env("CIRCLE_PROJECT_USERNAME")?,
-            project_reponame: env("CIRCLE_PROJECT_REPONAME")?,
-            branch: env("CIRCLE_BRANCH"),
-            tag: env("CIRCLE_TAG"),
-            sha1: env("CIRCLE_SHA1")?,
-            repository_url: env("CIRCLE_REPOSITORY_URL")?,
-            compare_url: env("CIRCLE_COMPARE_URL"),
-            build_url: env("CIRCLE_BUILD_URL")?,
-            build_num: env("CIRCLE_BUILD_NUM")?.parse().ok()?,
-            previous_build_num: env("CIRCLE_PREVIOUS_BUILD_NUM").and_then(|it| it.parse().ok()),
-            pull_requests: env("CI_PULL_REQUESTS"),
-            pull_request: env("CI_PULL_REQUEST"),
-            artifacts: env("CIRCLE_ARTIFACTS")?,
-            username: env("CIRCLE_USERNAME")?,
-            test_reports: env("CIRCLE_TEST_REPORTS")?,
-            pr_username: env("CIRCLE_PR_USERNAME"),
-            pr_reponame: env("CIRCLE_PR_REPONAME"),
-            pr_number: env("CIRCLE_PR_NUMBER").and_then(|it| it.parse().ok()),
-            node_total: env("CIRCLE_NODE_TOTAL")?.parse().ok()?,
-            node_index: env("CIRCLE_NODE_INDEX")?.parse().ok()?,
-            build_image: env("CIRCLE_BUILD_IMAGE")?,
-            non_exhaustive: (),
-        })
+        #[ci(env(CIRCLE_TAG))]
+        /// The name of the git tag being tested, e.g. `release-v1.5.4`,
+        /// if the build is running [for a tag](https://circleci.com/docs/1.0/configuration/#tags).
+        tag: String?,
+
+        #[ci(env(CIRCLE_SHA1))]
+        /// The SHA1 of the commit being tested.
+        sha1: String!,
+
+        #[ci(env(CIRCLE_REPOSITORY_URL))]
+        /// A link to the homepage for the current repository,
+        /// for example, `https://github.com/circleci/frontend`.
+        repository_url: String!,
+
+        #[ci(env(CIRCLE_COMPARE_URL))]
+        /// A link to GitHub’s comparison view for this push.
+        /// Not present for builds that are triggered by GitHub pushes.
+        compare_url: String?,
+
+        #[ci(env(CIRCLE_BUILD_URL))]
+        /// A permanent link to the current build,
+        /// for example, `https://circleci.com/gh/circleci/frontend/933`.
+        build_url: String!,
+
+        #[ci(env(CIRCLE_BUILD_NUM))]
+        /// The build number, same as in `circleci.com/gh/foo/bar/123`
+        build_num: usize!,
+
+        #[ci(env(CIRCLE_PREVIOUS_BUILD_NUM))]
+        /// The build number of the previous build, same as in `circleci.com/gh/foo/bar/123`
+        previous_build_num: usize?,
+
+        #[ci(env(CIRCLE_PULL_REQUESTS))]
+        /// Comma-separated list of pull requests this build is a part of.
+        pull_requests: String?,
+
+        #[ci(env(CIRCLE_PULL_REQUEST))]
+        /// If this build is part of only one pull request, its URL will be populated here. If there was
+        /// more than one pull request, it will contain one of the pull request URLs (picked randomly).
+        pull_request: String?,
+
+        #[ci(env(CIRCLE_ARTIFACTS))]
+        /// The directory whose contents are automatically saved as
+        /// [build artifacts](https://circleci.com/docs/1.0/build-artifacts/).
+        artifacts: String!,
+
+        #[ci(env(CIRCLE_USERNAME))]
+        /// The GitHub login of the user who either pushed the code
+        /// to GitHub or triggered the build from the UI/API.
+        username: String!,
+
+        #[ci(env(CIRCLE_TEST_REPORTS))]
+        /// The directory whose contents are automatically processed as
+        /// [JUnit test metadata](https://circleci.com/docs/1.0/test-metadata/).
+        test_reports: String!,
+
+        #[ci(env(CIRCLE_PR_USERNAME))]
+        /// When the build is a part of a pull request from a fork,
+        /// The username of the owner of the fork.
+        pr_username: String?,
+
+        #[ci(env(CIRCLE_PR_REPONAME))]
+        /// When the build is a part of a pull request from a fork,
+        /// The name of the repository the pull request was submitted from.
+        pr_reponame: String?,
+
+        #[ci(env(CIRCLE_PR_NUMBER))]
+        /// When the build is a part of a pull request from a fork,
+        /// The number of the pull request this build forms part of.
+        pr_number: usize?,
+
+        #[ci(env(CIRCLE_NODE_TOTAL))]
+        /// The total number of nodes across which the current test is running.
+        node_total: usize!,
+
+        #[ci(env(CIRCLE_NODE_INDEX))]
+        /// The index (0-based) of the current node.
+        node_index: usize!,
+
+        #[ci(env(CIRCLE_BUILD_IMAGE))]
+        /// The build image this build runs on.
+        build_image: String!,
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,19 +13,19 @@
 #[cfg_attr(feature = "nightly", non_exhaustive)]
 pub enum CI {
     // /// Jenkins CI
-    // Jenkins(Jenkins),
+    // Jenkins(Box<Jenkins>),
     // /// Travis CI
-    // Travis(Travis),
+    // Travis(Box<Travis>),
     // /// Docker
-    // Docker(Docker),
+    // Docker(Box<Docker>),
     // /// Codeship CI
-    // Codeship(Codeship),
+    // Codeship(Box<Codeship>),
     // /// Codefresh CI
-    // Codefresh(Codefresh),
+    // Codefresh(Box<Codefresh>),
     /// Circle CI
-    Circle(Circle),
+    Circle(Box<Circle>),
     // /// Appveyor CI
-    // Appveyor(Appveyor),
+    // Appveyor(Box<Appveyor>),
     #[doc(hidden)]
     __NonExhaustive,
 }
@@ -35,26 +35,26 @@ impl CI {
     #[cfg_attr(rustfmt, rustfmt_skip)]
     pub fn lazy() -> Option<Self> {
         None
-        //  .or_else(|| Jenkins  ::lazy().map(CI::Jenkins  ))
-        //  .or_else(|| Travis   ::lazy().map(CI::Travis   ))
-        //  .or_else(|| Docker   ::lazy().map(CI::Docker   ))
-        //  .or_else(|| Codeship ::lazy().map(CI::Codeship ))
-        //  .or_else(|| Codefresh::lazy().map(CI::Codefresh))
-            .or_else(|| Circle   ::lazy().map(CI::Circle   ))
-        //  .or_else(|| Appveyor ::lazy().map(CI::Appveyor ))
+        //  .or_else(|| Jenkins  ::lazy().map(|it| CI::Jenkins  (Box::new(it))))
+        //  .or_else(|| Travis   ::lazy().map(|it| CI::Travis   (Box::new(it))))
+        //  .or_else(|| Docker   ::lazy().map(|it| CI::Docker   (Box::new(it))))
+        //  .or_else(|| Codeship ::lazy().map(|it| CI::Codeship (Box::new(it))))
+        //  .or_else(|| Codefresh::lazy().map(|it| CI::Codefresh(Box::new(it))))
+            .or_else(|| Circle   ::lazy().map(|it| CI::Circle   (Box::new(it))))
+        //  .or_else(|| Appveyor ::lazy().map(|it| CI::Appveyor (Box::new(it))))
     }
 
     /// Grab the CI environment information eagerly
     #[cfg_attr(rustfmt, rustfmt_skip)]
     pub fn eager() -> Option<Self> {
         None
-        //  .or_else(|| Jenkins  ::lazy().map(|mut it| { it.load(); Jenkins  (it) }))
-        //  .or_else(|| Travis   ::lazy().map(|mut it| { it.load(); Travis   (it) }))
-        //  .or_else(|| Docker   ::lazy().map(|mut it| { it.load(); Docker   (it) }))
-        //  .or_else(|| Codeship ::lazy().map(|mut it| { it.load(); Codeship (it) }))
-        //  .or_else(|| Codefresh::lazy().map(|mut it| { it.load(); Codefresh(it) }))
-            .or_else(|| Circle   ::lazy().map(|mut it| { it.load(); CI::Circle   (it) }))
-        //  .or_else(|| Appveyor ::lazy().map(|mut it| { it.load(); Appveyor (it) }))
+        //  .or_else(|| Jenkins  ::lazy().map(|mut it| { it.load(); CI::Jenkins  (Box::new(it)) }))
+        //  .or_else(|| Travis   ::lazy().map(|mut it| { it.load(); CI::Travis   (Box::new(it)) }))
+        //  .or_else(|| Docker   ::lazy().map(|mut it| { it.load(); CI::Docker   (Box::new(it)) }))
+        //  .or_else(|| Codeship ::lazy().map(|mut it| { it.load(); CI::Codeship (Box::new(it)) }))
+        //  .or_else(|| Codefresh::lazy().map(|mut it| { it.load(); CI::Codefresh(Box::new(it)) }))
+            .or_else(|| Circle   ::lazy().map(|mut it| { it.load(); CI::Circle   (Box::new(it)) }))
+        //  .or_else(|| Appveyor ::lazy().map(|mut it| { it.load(); CI::Appveyor (Box::new(it)) }))
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -166,14 +166,18 @@ macro_rules! ci {
         }
     };
 
-    (__impl #[ci(env($member_env:ident))] $(#[$member_doc:meta])* $member:ident? : $member_ty:ty) => {
+    (__impl
+        #[ci(env($member_env:ident))] $(#[$member_doc:meta])* $member:ident? : $member_ty:ty
+    ) => {
         $(#[$member_doc])*
         pub fn $member(&mut self) -> Option<&$member_ty> {
             self.$member.get()
         }
     };
 
-    (__impl #[ci(env($member_env:ident))] $(#[$member_doc:meta])* $member:ident! : $member_ty:ty) => {
+    (__impl
+        #[ci(env($member_env:ident))] $(#[$member_doc:meta])* $member:ident! : $member_ty:ty
+    ) => {
         $(#[$member_doc])*
         pub fn $member(&mut self) -> &$member_ty {
             self.$member.get().unwrap_or_else(|| panic!(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,7 +3,6 @@
 //! Documentation of individual build environment variables is from the appropriate
 //! documentation and is copyright the provider under the original license
 
-#![warn(warnings)]
 #![forbid(missing_debug_implementations, unconditional_recursion, future_incompatible)]
 #![deny(bad_style, missing_docs, unsafe_code, unused)]
 #![warn(unreachable_pub)]
@@ -13,35 +12,49 @@
 #[derive(Clone, Debug)]
 #[cfg_attr(feature = "nightly", non_exhaustive)]
 pub enum CI {
-    /// Jenkins CI
-    Jenkins(Jenkins),
-    /// Travis CI
-    Travis(Travis),
-    /// Docker
-    Docker(Docker),
-    /// Codeship CI
-    Codeship(Codeship),
-    /// Codefresh CI
-    Codefresh(Codefresh),
+    // /// Jenkins CI
+    // Jenkins(Jenkins),
+    // /// Travis CI
+    // Travis(Travis),
+    // /// Docker
+    // Docker(Docker),
+    // /// Codeship CI
+    // Codeship(Codeship),
+    // /// Codefresh CI
+    // Codefresh(Codefresh),
     /// Circle CI
     Circle(Circle),
-    /// Appveyor CI
-    Appveyor(Appveyor),
-    #[doc(hidden)] __NonExhaustive,
+    // /// Appveyor CI
+    // Appveyor(Appveyor),
+    #[doc(hidden)]
+    __NonExhaustive,
 }
 
 impl CI {
-    /// Grab the CI environment information
+    /// Grab the CI environment information lazily
     #[cfg_attr(rustfmt, rustfmt_skip)]
-    pub fn from_env() -> Option<Self> {
+    pub fn lazy() -> Option<Self> {
         None
-            .or_else(|| Jenkins  ::from_env().map(CI::Jenkins  ))
-            .or_else(|| Travis   ::from_env().map(CI::Travis   ))
-            .or_else(|| Docker   ::from_env().map(CI::Docker   ))
-            .or_else(|| Codeship ::from_env().map(CI::Codeship ))
-            .or_else(|| Codefresh::from_env().map(CI::Codefresh))
-            .or_else(|| Circle   ::from_env().map(CI::Circle   ))
-            .or_else(|| Appveyor ::from_env().map(CI::Appveyor ))
+        //  .or_else(|| Jenkins  ::lazy().map(CI::Jenkins  ))
+        //  .or_else(|| Travis   ::lazy().map(CI::Travis   ))
+        //  .or_else(|| Docker   ::lazy().map(CI::Docker   ))
+        //  .or_else(|| Codeship ::lazy().map(CI::Codeship ))
+        //  .or_else(|| Codefresh::lazy().map(CI::Codefresh))
+            .or_else(|| Circle   ::lazy().map(CI::Circle   ))
+        //  .or_else(|| Appveyor ::lazy().map(CI::Appveyor ))
+    }
+
+    /// Grab the CI environment information eagerly
+    #[cfg_attr(rustfmt, rustfmt_skip)]
+    pub fn eager() -> Option<Self> {
+        None
+        //  .or_else(|| Jenkins  ::lazy().map(|mut it| { it.load(); Jenkins  (it) }))
+        //  .or_else(|| Travis   ::lazy().map(|mut it| { it.load(); Travis   (it) }))
+        //  .or_else(|| Docker   ::lazy().map(|mut it| { it.load(); Docker   (it) }))
+        //  .or_else(|| Codeship ::lazy().map(|mut it| { it.load(); Codeship (it) }))
+        //  .or_else(|| Codefresh::lazy().map(|mut it| { it.load(); Codefresh(it) }))
+            .or_else(|| Circle   ::lazy().map(|mut it| { it.load(); CI::Circle   (it) }))
+        //  .or_else(|| Appveyor ::lazy().map(|mut it| { it.load(); Appveyor (it) }))
     }
 }
 
@@ -54,25 +67,125 @@ fn env(var: &str) -> Option<String> {
     }
 }
 
-/// Jenkins CI
-pub mod jenkins;
-pub use jenkins::Jenkins;
+#[derive(Copy, Clone, Debug)]
+struct LazyEnv<T: std::str::FromStr>(Option<T>, &'static str);
 
-/// Travis CI
-pub mod travis;
-pub use travis::Travis;
+impl<T: std::str::FromStr> LazyEnv<T> {
+    fn new(var: &'static str) -> Self {
+        LazyEnv(None, var)
+    }
 
-/// Docker
-pub mod docker;
-pub use docker::Docker;
+    // TODO(CAD): Hide mutability with Cell?
+    fn get(&mut self) -> Option<&T> {
+        if self.0.is_none() {
+            self.0 = env(self.1).and_then(|it| it.parse().ok());
+        }
+        self.0.as_ref()
+    }
+}
 
-/// Codeship CI
-pub mod codeship;
-pub use codeship::Codeship;
+// TODO(CAD): Make this an actual proc macro for proper attribute handling?
+// This will require removing the ?/! sugar.
+macro_rules! ci {
+    (
+        //$(#[ci(require($require_environment_present:ident))])*;
+        // TODO(FUTURE-RUST#48075): Kleene Operator for trailing comma
+        #[ci(require($($require_environment_var:ident = $require_environment_val:expr),+$(,)*))]
+        $(#[$struct_doc:meta])*
+        pub struct $CI:ident {$(
+            #[ci(env($member_env:ident))]
+            $(#[$member_doc:meta])*
+            $member:ident: $member_ty:ident $optionality:tt ,
+        )*}
+    ) => {
+        $(#[$struct_doc])*
+        #[derive(Clone, Debug)]
+        pub struct $CI {$(
+            $member: ::LazyEnv<$member_ty>,
+        )*}
 
-/// Codefresh CI
-pub mod codefresh;
-pub use codefresh::Codefresh;
+        impl $CI {$(
+            ci!{__impl $(#[$member_doc])* $member $optionality : $member_ty}
+        )*}
+
+        impl $CI {
+            /// Construct a lazy instance of this CI's configuration.
+            ///
+            /// Returns None if the environment doesn't look like the CI's.
+            /// Most CI has a set of environment variables which identify it,
+            /// such as `TRAVIS=true` for Travis CI. Those are checked eagerly
+            /// here.
+            pub fn lazy() -> Option<Self> {
+                if !(
+                    //$(::env($require_environment_present).is_some() &&)*
+                    $(::env(stringify!($require_environment_var))? == $require_environment_val &&)*
+                    true
+                ) { return None; }
+                Some($CI {$(
+                    $member: ::LazyEnv::new(stringify!($member_env)),
+                )*})
+            }
+
+            pub(crate) fn load(&mut self) {
+                $(let _ = self.$member();)*
+            }
+
+            /// Construct an instance of this CI's configuration and load it eagerly.
+            ///
+            /// # Panics
+            ///
+            /// If any of the expected environment variables are not present.
+            pub fn eager() -> Self {
+                let mut ci = Self::lazy().expect(concat!(
+                    "Environment does not look like ",
+                    stringify!($CI),
+                ));
+                ci.load();
+                ci
+            }
+        }
+    };
+
+    (__impl $(#[$member_doc:meta])* $member:ident? : $member_ty:ty) => {
+        $(#[$member_doc])*
+        pub fn $member(&mut self) -> Option<&$member_ty> {
+            self.$member.get()
+        }
+    };
+
+    (__impl $(#[$member_doc:meta])* $member:ident! : $member_ty:ty) => {
+        $(#[$member_doc])*
+        pub fn $member(&mut self) -> &$member_ty {
+            self.$member.get().expect(concat!(
+                "Environment variable ",
+                stringify!($member),
+                " expected to parse to ",
+                stringify!($member_ty),
+                " but failed",
+            ))
+        }
+    };
+}
+
+///// Jenkins CI
+//pub mod jenkins;
+//pub use jenkins::Jenkins;
+//
+///// Travis CI
+//pub mod travis;
+//pub use travis::Travis;
+//
+///// Docker
+//pub mod docker;
+//pub use docker::Docker;
+//
+///// Codeship CI
+//pub mod codeship;
+//pub use codeship::Codeship;
+//
+///// Codefresh CI
+//pub mod codefresh;
+//pub use codefresh::Codefresh;
 
 // TeamCity CI doesn't provide environment variables by default
 // <https://github.com/codecov/codecov-bash/blob/8b76995ad4a95a61cecd4b049a448a402d91d197/codecov#L521-L547>
@@ -81,6 +194,6 @@ pub use codefresh::Codefresh;
 pub mod circle;
 pub use circle::Circle;
 
-/// Appveyor CI
-pub mod appveyor;
-pub use appveyor::Appveyor;
+///// Appveyor CI
+//pub mod appveyor;
+//pub use appveyor::Appveyor;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -125,7 +125,7 @@ macro_rules! ci {
         )*}
 
         impl $CI {$(
-            ci!{__impl $(#[$member_doc])* $member $optionality : $member_ty}
+            ci!{__impl #[ci(env($member_env))] $(#[$member_doc])* $member $optionality : $member_ty}
         )*}
 
         impl $CI {
@@ -166,22 +166,19 @@ macro_rules! ci {
         }
     };
 
-    (__impl $(#[$member_doc:meta])* $member:ident? : $member_ty:ty) => {
+    (__impl #[ci(env($member_env:ident))] $(#[$member_doc:meta])* $member:ident? : $member_ty:ty) => {
         $(#[$member_doc])*
         pub fn $member(&mut self) -> Option<&$member_ty> {
             self.$member.get()
         }
     };
 
-    (__impl $(#[$member_doc:meta])* $member:ident! : $member_ty:ty) => {
+    (__impl #[ci(env($member_env:ident))] $(#[$member_doc:meta])* $member:ident! : $member_ty:ty) => {
         $(#[$member_doc])*
         pub fn $member(&mut self) -> &$member_ty {
-            self.$member.get().expect(concat!(
-                "Environment variable ",
-                stringify!($member),
-                " expected to parse to ",
-                stringify!($member_ty),
-                " but failed",
+            self.$member.get().unwrap_or_else(|| panic!(
+                "Environment variable {} expected to parse to {} but failed; was {:?}",
+                stringify!($member_env), stringify!($member_ty), ::env(stringify!($member_env)),
             ))
         }
     };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,9 @@
 #![warn(unreachable_pub)]
 #![cfg_attr(feature = "nightly", feature(non_exhaustive))]
 
+#[macro_use]
+extern crate ci_detective_internal_derive;
+
 /// Grab the configuration from whatever CI you're on.
 #[derive(Clone, Debug)]
 #[cfg_attr(feature = "nightly", non_exhaustive)]
@@ -65,127 +68,6 @@ fn env(var: &str) -> Option<String> {
     } else {
         None
     }
-}
-
-// TODO(CAD): Hide mutability with Cell?
-// TODO(FUTURE_RUST(1.26)): Use FromStr again (revert this line's blame)
-#[derive(Copy, Clone, Debug)]
-struct LazyEnv<T>(Option<T>, &'static str);
-
-impl<T> LazyEnv<T> {
-    fn new(var: &'static str) -> Self {
-        LazyEnv(None, var)
-    }
-}
-
-macro_rules! lazy_env_get {
-    (::std::path::PathBuf) => {
-        impl LazyEnv<::std::path::PathBuf> {
-            fn get(&mut self) -> Option<&::std::path::PathBuf> {
-                if self.0.is_none() {
-                    self.0 = env(self.1).map(Into::into);
-                }
-                self.0.as_ref()
-            }
-        }
-    };
-    ($ty:ty) => {
-        impl LazyEnv<$ty> {
-            fn get(&mut self) -> Option<&$ty> {
-                if self.0.is_none() {
-                    self.0 = env(self.1).and_then(|it| it.parse().ok());
-                }
-                self.0.as_ref()
-            }
-        }
-    };
-    ($head:ty, $($tail:tt)*) => { lazy_env_get!($head); lazy_env_get!($($tail)*); };
-    (,) => {}
-}
-lazy_env_get!(u32, String, ::std::path::PathBuf);
-
-// TODO(CAD): Make this an actual proc macro for proper attribute handling?
-// This will require removing the ?/! sugar.
-macro_rules! ci {
-    (
-        //$(#[ci(require($require_environment_present:ident))])*;
-        // TODO(FUTURE-RUST#48075): Kleene Operator for trailing comma
-        #[ci(require($($require_environment_var:ident = $require_environment_val:expr),+$(,)*))]
-        $(#[$struct_doc:meta])*
-        pub struct $CI:ident {$(
-            #[ci(env($member_env:ident))]
-            $(#[$member_doc:meta])*
-            $member:ident: $member_ty:ident $optionality:tt ,
-        )*}
-    ) => {
-        $(#[$struct_doc])*
-        #[derive(Clone, Debug)]
-        pub struct $CI {$(
-            $member: ::LazyEnv<$member_ty>,
-        )*}
-
-        impl $CI {$(
-            ci!{__impl #[ci(env($member_env))] $(#[$member_doc])* $member $optionality : $member_ty}
-        )*}
-
-        impl $CI {
-            /// Construct a lazy instance of this CI's configuration.
-            ///
-            /// Returns None if the environment doesn't look like the CI's.
-            /// Most CI has a set of environment variables which identify it,
-            /// such as `TRAVIS=true` for Travis CI. Those are checked eagerly
-            /// here.
-            pub fn lazy() -> Option<Self> {
-                if !(
-                    //$(::env($require_environment_present).is_some() &&)*
-                    $(::env(stringify!($require_environment_var))? == $require_environment_val &&)*
-                    true
-                ) { return None; }
-                Some($CI {$(
-                    $member: ::LazyEnv::new(stringify!($member_env)),
-                )*})
-            }
-
-            pub(crate) fn load(&mut self) {
-                $(let _ = self.$member();)*
-            }
-
-            /// Construct an instance of this CI's configuration and load it eagerly.
-            ///
-            /// # Panics
-            ///
-            /// If any of the expected environment variables are not present.
-            pub fn eager() -> Self {
-                let mut ci = Self::lazy().expect(concat!(
-                    "Environment does not look like ",
-                    stringify!($CI),
-                ));
-                ci.load();
-                ci
-            }
-        }
-    };
-
-    (__impl
-        #[ci(env($member_env:ident))] $(#[$member_doc:meta])* $member:ident? : $member_ty:ty
-    ) => {
-        $(#[$member_doc])*
-        pub fn $member(&mut self) -> Option<&$member_ty> {
-            self.$member.get()
-        }
-    };
-
-    (__impl
-        #[ci(env($member_env:ident))] $(#[$member_doc:meta])* $member:ident! : $member_ty:ty
-    ) => {
-        $(#[$member_doc])*
-        pub fn $member(&mut self) -> &$member_ty {
-            self.$member.get().unwrap_or_else(|| panic!(
-                "Environment variable {} expected to parse to {} but failed; was {:?}",
-                stringify!($member_env), stringify!($member_ty), ::env(stringify!($member_env)),
-            ))
-        }
-    };
 }
 
 ///// Jenkins CI

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -67,6 +67,7 @@ fn env(var: &str) -> Option<String> {
     }
 }
 
+// TODO(CAD): Hide mutability with Cell?
 #[derive(Copy, Clone, Debug)]
 struct LazyEnv<T: std::str::FromStr>(Option<T>, &'static str);
 
@@ -75,7 +76,6 @@ impl<T: std::str::FromStr> LazyEnv<T> {
         LazyEnv(None, var)
     }
 
-    // TODO(CAD): Hide mutability with Cell?
     fn get(&mut self) -> Option<&T> {
         if self.0.is_none() {
             self.0 = env(self.1).and_then(|it| it.parse().ok());

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,7 @@
 extern crate ci_detective;
 
 fn main() {
-    if let Some(ci) = ci_detective::CI::from_env() {
+    if let Some(ci) = ci_detective::CI::eager() {
         println!("{:?}", ci);
     }
 }


### PR DESCRIPTION
As it turns out, the macro interface is _probably_ possible using just macro-by-example, even if it has a few shortcomings (read: the `#[ci]` has to come before the doc comments).

I still need to convert the other added providers (or at least AppVeyor and Travis) to the new format, but everything _should_ transfer over, though I'll probably have to flatten Jenkins' GHPRB.

Does this shape meet your use case, @epage ? We can add a trait on top and provide a `ci_info() -> dyn CommonCIInfo` for portable information.