### PR TITLE
Break badges onto two lines: CI/not

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![Appveyor](https://ci.appveyor.com/api/projects/status/ane9s9m78ij6i1hq/branch/master?svg=true)](https://ci.appveyor.com/project/epage/ci-detective/branch/master)
 [![Codeship](https://app.codeship.com/projects/d498c1e0-f33e-0136-19a0-4e3e1edea9c6/status?branch=master)](https://app.codeship.com/projects/320593)
 [![CircleCI](https://circleci.com/gh/crate-ci/ci-detective/tree/master.svg?style=svg)](https://circleci.com/gh/crate-ci/ci-detective/tree/master)
-[![Azure Pipelines](https://dev.azure.com/eopage/ci-detective/_apis/build/status/crate-ci.ci-detective?branchName=master)](https://dev.azure.com/eopage/ci-detective/_build/latest?definitionId=1?branchName=master)
+[![Azure Pipelines](https://dev.azure.com/eopage/ci-detective/_apis/build/status/crate-ci.ci-detective?branchName=master)](https://dev.azure.com/eopage/ci-detective/_build/latest?definitionId=1?branchName=master)  
 [![Documentation](https://img.shields.io/badge/docs-master-blue.svg)][Documentation]
 ![License](https://img.shields.io/crates/l/ci-detective.svg)
 [![crates.io](https://img.shields.io/crates/v/ci-detective.svg)][Crates.io]


### PR DESCRIPTION
cc #9 

Will this actually stay? Markdown has semantic whitespace at the end of the line to add line breaks that aren't paragraph breaks, and I know most code editors are eager to remove trailing whitespace.